### PR TITLE
[Fix] this module make the validation return false result while the condition where exact.

### DIFF
--- a/src/Core/Validation/Providers/ValidatorProvider.php
+++ b/src/Core/Validation/Providers/ValidatorProvider.php
@@ -117,9 +117,9 @@ abstract class ValidatorProvider implements Contracts
      * @param bool $max
      * @return bool
      */
-    protected function positiveParamMethod(int $rule, bool $max = false): bool
+    protected function checkNotPositiveParamMethod(int $rule, bool $max = false): bool
     {
-        $status = true;
+        $status = false;
         if ($rule < 1) {
             $method = $max ? "max" : "min";
             $this->messageItem
@@ -127,7 +127,7 @@ abstract class ValidatorProvider implements Contracts
                 ->message("'$this->field_name' $method param should be a positive number")
                 ->label($this->field_name);
             $this->addError($this->messageItem);
-            $status = false;
+            $status = true;
         }
         return $status;
     }

--- a/src/Core/Validation/Validator/ArrayValidator.php
+++ b/src/Core/Validation/Validator/ArrayValidator.php
@@ -35,7 +35,7 @@ final class ArrayValidator extends ValidatorProvider
     public function min(int $rule): void
     {
         // TODO: Implement min() method.
-        if ($this->positiveParamMethod($rule)) return;
+        if ($this->checkNotPositiveParamMethod($rule)) return;
         if (count($this->field_value) < $rule) {
             $this->messageItem
                 ->type('array.min')
@@ -53,7 +53,7 @@ final class ArrayValidator extends ValidatorProvider
     public function max(int $rule): void
     {
         // TODO: Implement max() method.
-        if ($this->positiveParamMethod($rule, true)) return;
+        if ($this->checkNotPositiveParamMethod($rule, true)) return;
         if (count($this->field_value) > $rule) {
             $this->messageItem
                 ->type('array.max')

--- a/src/Core/Validation/Validator/NumberValidator.php
+++ b/src/Core/Validation/Validator/NumberValidator.php
@@ -43,7 +43,7 @@ final class NumberValidator extends ValidatorProvider
      */
     public function min(int $rule)
     {
-        if ($this->positiveParamMethod($rule)) return;
+        if ($this->checkNotPositiveParamMethod($rule)) return;
         if ((int)$this->field_value < $rule) {
             $this->messageItem
                 ->type('number.min')
@@ -60,7 +60,7 @@ final class NumberValidator extends ValidatorProvider
      */
     public function max(int $rule)
     {
-        if ($this->positiveParamMethod($rule, true)) return;
+        if ($this->checkNotPositiveParamMethod($rule, true)) return;
         if ((int)$this->field_value > $rule) {
             $this->messageItem
                 ->type('number.max')

--- a/src/Core/Validation/Validator/StringValidator.php
+++ b/src/Core/Validation/Validator/StringValidator.php
@@ -39,7 +39,7 @@ final class StringValidator extends ValidatorProvider
      */
     public function min(int $rule): void
     {
-        if ($this->positiveParamMethod($rule)) return;
+        if ($this->checkNotPositiveParamMethod($rule)) return;
         if (strlen($this->field_value) < $rule) {
             $this->messageItem
                 ->type('string.min')
@@ -57,7 +57,7 @@ final class StringValidator extends ValidatorProvider
      */
     public function max(int $rule): void
     {
-        if ($this->positiveParamMethod($rule, true)) return;
+        if ($this->checkNotPositiveParamMethod($rule, true)) return;
         if (strlen($this->field_value) > $rule) {
             $this->messageItem
                 ->type('string.max')


### PR DESCRIPTION
While validate a schema, in case the condition where meet unexpectedly it return error, but when the condition is not met it passed, which was confusing. the problem come from a module that help to validate positive value.
closes #98 