### PR TITLE
[ENH] refactoring entity structure into ORM module

### DIFF
--- a/controller/homeController.php
+++ b/controller/homeController.php
@@ -12,6 +12,7 @@ use Wepesi\Core\Input;
 use Wepesi\Core\Redirect;
 use Wepesi\Core\Session;
 
+
 class homeController{
 
     /**

--- a/src/Core/BaseEntityModel/Provider/Contract/EntityInterface.php
+++ b/src/Core/BaseEntityModel/Provider/Contract/EntityInterface.php
@@ -1,6 +1,0 @@
-<?php
-namespace Wepesi\Core\BaseEntityModel\Provider\Contract;
-
-interface EntityInterface {
-    public function findAll():array;
-}

--- a/src/Core/Orm/EntityModel/EntityReflexion.php
+++ b/src/Core/Orm/EntityModel/EntityReflexion.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Wepesi\Core\BaseEntityModel;
+namespace Wepesi\Core\Orm\EntityModel;
 
-use Wepesi\Core\BaseEntityModel\Provider\Contract\EntityInterface;
+use Wepesi\Core\Orm\EntityModel\Provider\Contract\EntityInterface;
 
 /**
  *

--- a/src/Core/Orm/EntityModel/Provider/Contract/EntityInterface.php
+++ b/src/Core/Orm/EntityModel/Provider/Contract/EntityInterface.php
@@ -1,0 +1,7 @@
+<?php
+namespace Wepesi\Core\Orm\EntityModel\Provider\Contract;
+
+interface EntityInterface {
+    public function findAll():array;
+    public function findOne():array;
+}

--- a/src/Core/Orm/EntityModel/Provider/Entity.php
+++ b/src/Core/Orm/EntityModel/Provider/Entity.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace Wepesi\Core\BaseEntityModel\Provider;
+namespace Wepesi\Core\Orm\EntityModel\Provider;
 
-use phpDocumentor\Reflection\Types\This;
-use Wepesi\Core\BaseEntityModel\EntityReflexion;
-use Wepesi\Core\BaseEntityModel\Provider\Contract\EntityInterface;
+use Wepesi\Core\Orm\EntityModel\EntityReflexion;
+use Wepesi\Core\Orm\EntityModel\Provider\Contract\EntityInterface;
 use Wepesi\Core\Orm\DB;
 use Wepesi\Core\Orm\Relations\HasMany;
 use Wepesi\Core\Orm\Relations\HasOne;

--- a/src/Core/Orm/Relations/BaseRelation.php
+++ b/src/Core/Orm/Relations/BaseRelation.php
@@ -2,8 +2,8 @@
 
 namespace Wepesi\Core\Orm\Relations;
 
-use Wepesi\Core\BaseEntityModel\EntityReflexion;
-use Wepesi\Core\BaseEntityModel\Provider\Contract\EntityInterface;
+use Wepesi\Core\Orm\EntityModel\EntityReflexion;
+use Wepesi\Core\Orm\EntityModel\Provider\Contract\EntityInterface;
 /**
  *
  */

--- a/src/Core/Orm/Relations/HasMany.php
+++ b/src/Core/Orm/Relations/HasMany.php
@@ -2,7 +2,7 @@
 
 namespace Wepesi\Core\Orm\Relations;
 
-use Wepesi\Core\BaseEntityModel\Provider\Contract\EntityInterface;
+use Wepesi\Core\Orm\EntityModel\Provider\Contract\EntityInterface;
 
 
 /**

--- a/src/Core/Orm/Relations/HasOne.php
+++ b/src/Core/Orm/Relations/HasOne.php
@@ -2,7 +2,7 @@
 
 namespace Wepesi\Core\Orm\Relations;
 
-use Wepesi\Core\BaseEntityModel\Provider\Contract\EntityInterface;
+use Wepesi\Core\Orm\EntityModel\Provider\Contract\EntityInterface;
 
 /**
  *


### PR DESCRIPTION
It required to restructure the entity into the ORM module because it was linked.
closes #120 