### PR TITLE
[ENH] remove unused packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,9 +44,5 @@
     "require": {
         "php" : ">=7.4",
       "ext-mbstring": "*"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "9.5",
-        "squizlabs/php_codesniffer": "4.0.x-dev"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,21 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "1672b0fbbe00eb53e9c4c59acb2706ca",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.4",
+        "ext-mbstring": "*"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.2.0"
+}


### PR DESCRIPTION
some unused package make the installatio of the project via composer to take somuch time , while they are not used.
Better to use tar ball for `phpunit`, give more flexibility.
closes #123 