### PR TITLE
[FIX] try to access undefined object

### DIFF
--- a/src/Core/Orm/Traits/QueryExecuter.php
+++ b/src/Core/Orm/Traits/QueryExecuter.php
@@ -48,7 +48,7 @@ trait QueryExecuter
 
                 switch ($sql_string[0]) {
                     case 'select' :
-                        if (count($this->include_object) > 0) {
+                        if (isset($this->include_object) && count($this->include_object) > 0) {
                             $data_result['result'] = $query->fetchAll(\PDO::FETCH_GROUP);
                         } else {
                             $data_result['result'] = $query->fetchAll(\PDO::FETCH_OBJ);


### PR DESCRIPTION
There was a problem while insert an new information, it calls for the include object which is not defined in the insert class. 
It required to check if the object exist.
closes #128.