### PR TITLE
[FIX] Entity save: unable to retrieve last record saved id.

### DIFF
--- a/src/Core/Orm/Traits/QueryExecuter.php
+++ b/src/Core/Orm/Traits/QueryExecuter.php
@@ -19,12 +19,12 @@ trait QueryExecuter
      * @param array $params
      * @return array
      */
-    protected function executeQuery(\PDO $pdo, string $sql, array $params = []): array
+    protected function executeQuery(\PDO $pdo, string $sql, array $params = [],int $last_id = -1): array
     {
         try {
             $data_result = [
                 'result' => [],
-                'lastID' => -1,
+                'lastID' => $last_id,
                 'count' => 0,
                 'error' => "",
             ];
@@ -56,11 +56,11 @@ trait QueryExecuter
                         $data_result['count'] = $query->columnCount();
                         break;
                     case 'insert' :
-                        $last_id = $pdo->lastInsertId();
+                        $last_id = (int)$pdo->lastInsertId();
                         $data_result['lastID'] = $last_id;
                         $data_result['count'] = $query->rowCount();
                         $sql = "SELECT * FROM $this->table WHERE id=?";
-                        return $this->executeQuery($pdo, $sql, [$last_id]);
+                        return $this->executeQuery($pdo, $sql, [$last_id],$last_id);
                         break;
                     case 'update':
                         $data_result['count'] = $query->rowCount();


### PR DESCRIPTION
While saved the an new record it was not able to retrieve the last ID because the last id was not provided because we use `executeQuery` method to get the data from the last record. so, we lost the last id. and it return -1. 

closes #129  