### PR TITLE
[UPD] ORM Update: get array without key in case of key duplication

### DIFF
--- a/src/Core/Orm/DBUpdate.php
+++ b/src/Core/Orm/DBUpdate.php
@@ -102,8 +102,8 @@ class DBUpdate extends DbProvider
         $where_params = $this->where['params'] ?? [];
         $fields = $this->_fields['keys'];
         $field_params = $this->_fields['params'] ?? [];
-        $params = array_merge($field_params, $where_params);
-        //generate the sql query to be execute
+        $params = array_merge(array_values($field_params),array_values($where_params));
+        //generate the sql query to be executed
         $sql = "UPDATE $this->table SET $fields  $where";
         $this->query($sql, $params);
     }


### PR DESCRIPTION
In case we have duplication key it will not be possible to get all information, in case we have a key on the field and on the where condition.
The solution is to get only key value to avoid such problem.
closes #130 