### PR TITLE
[FIX] ORM Select: try to format data from empty result

### DIFF
--- a/src/Core/Orm/DBSelect.php
+++ b/src/Core/Orm/DBSelect.php
@@ -208,7 +208,7 @@ class DBSelect extends DbProvider
     public function result(): array
     {
         $this->build();
-        return (! isset($this->result['exception']) && count($this->include_object)>0) ? $this->formatData($this->result) : $this->result;
+        return (! isset($this->result['exception']) && count($this->include_object)>0 && count($this->result)>0) ? $this->formatData($this->result) : $this->result;
     }
 
     /**


### PR DESCRIPTION
While doing a select we call the `formatData` method to parse all data but in case there is not, is has been call which lead to unexpected error.