### PR TITLE
[FIX] ORM Entity : error executing delete method before apply condition.

### DIFF
--- a/src/Core/Orm/EntityModel/Provider/Entity.php
+++ b/src/Core/Orm/EntityModel/Provider/Entity.php
@@ -263,10 +263,10 @@ abstract class Entity implements EntityInterface
         try {
 
             $query = $this->db->delete($this->getTableName());
-            $result = $query->result();
             if (isset($this->param['where'])) {
                 $query->where($this->param['where']);
             }
+            $result = $query->result();
             $this->param = [];
             if ($this->db->error()) {
                 throw new \Exception($this->db->error());


### PR DESCRIPTION
There is a problem with Entity delete method, while trying to delete a row it clean-up the table and in case there is constraint, there will a problem.
The problem is that the condition is not take into consideration. The condition if check after execution.
closes #145 