### PR TITLE
[ENH] get formatted route path via function

### DIFF
--- a/config/function.php
+++ b/config/function.php
@@ -120,3 +120,12 @@ function tra(string $message, $value = null): string
     $translate_value = !is_array($value) ? [$value] : $value;
     return $i18n->translate($message, $translate_value);
 }
+
+/**
+ * get a formatted application route path
+ * @param string $path
+ * @return string
+ */
+function route_path(string $path): string{
+    return WEB_ROOT . ltrim($path,'/');
+}

--- a/config/globals.php
+++ b/config/globals.php
@@ -14,6 +14,5 @@ $GLOBALS['config'] = [
     'lang' => 'fr',
     'vendor' => true,
     'autoload' => ['src', 'controller', 'middleware', 'models', 'helpers'],
-    'helper' => WEB_ROOT,
-    'preferences' => WEB_ROOT . 'helper'
+    'helpers' => WEB_ROOT,
 ];

--- a/src/Core/MetaData.php
+++ b/src/Core/MetaData.php
@@ -267,7 +267,7 @@ class MetaData
     /**
      * @return string|null
      */
-    protected function getType(bool $twitter = fals): string
+    protected function getType(bool $twitter = false): string
     {
         $type = $twitter ? "<meta property=\"og:type\" content=\"$this->_type\" />" : "<meta name=\"twitter:type\" content=\"article\" />";
         return $this->_type ? $type : '';

--- a/src/Core/View.php
+++ b/src/Core/View.php
@@ -103,7 +103,7 @@ class View
      *
      * @param string $view
      */
-    function display(string $view)
+    public function display(string $view)
     {
         $view_file = $this->buildFilePath($view);
         $render = $this->renderView($view_file);
@@ -154,8 +154,7 @@ class View
      */
     private function renderNotDefined(string $file_name)
     {
-        Response::setStatusCode(404);
-        print_r(['exception' => "$file_name file path is not correct."]);
+        Response::send(['exception' => "$file_name file path is not correct."],404);
     }
 
     /**
@@ -208,12 +207,12 @@ class View
             $xpath = new DOMXPath($dom);
             $head = $xpath->query('//head/title');
             $template = $dom->createDocumentFragment();
-            // add style link to the head tag of the page
+            // add a style link to the head tag of the page
             foreach (self::$stylelink as $k => $v) {
                 $template->appendXML('<link rel="stylesheet" type="text/css" href="' . $v . '">');
                 $head[0]->parentNode->insertbefore($template, $head[0]->nextSibling);
             }
-            // add script link to the head of the page
+            // add a script link to the head of the page
             foreach (self::$jslink as $k => $v) {
                 $link = $v['link'];
                 $src = '<script src="' . $link . '" type="text/javascript"></script>';
@@ -224,7 +223,9 @@ class View
             // add metadata to the head of the page
             if (self::$metadata) {
                 $template->appendXML(self::$metadata);
-                $head[0]->parentNode->insertbefore($template, $head[0]->nextSibling);
+                if ($head[0]) {
+                    $head[0]->parentNode->insertbefore($template, $head[0]->nextSibling);
+                }
             }
             print(html_entity_decode($dom->saveHTML()));
         } catch (Exception $ex) {

--- a/views/404.php
+++ b/views/404.php
@@ -16,7 +16,7 @@
 <body>
 <div class="w3-margin w3-center">
     <h1 class="w3-text-green ">404</h1>
-    <p><a href="<?= WEB_ROOT ?>">Go home</a></p>
+    <p><a href="<?= route_path('/') ?>">Go home</a></p>
 </div>
 </body>
 </html>

--- a/views/home.php
+++ b/views/home.php
@@ -44,7 +44,7 @@ $language = new I18n($lang);
     <?php } ?>
     <div class="w3-card w3-border w3-round-large " style="width: 300px;overflow: hidden">
         <h3 class="w3-text-blue-gray w3-padding"><?= $language->translate("Change the language") ?></h3>
-        <form action="<?= WEB_ROOT . "changelang" ?>" method="post">
+        <form action="<?= route_path("/changelang") ?>" method="post">
             <input type="hidden" name="token" value="<?= Token::generate() ?>">
             <select name="lang" id="lang_id" class="w3-select w3-center">
                 <option value="" class="w3-center w3-large" disabled selected><?= $lang ?></option>


### PR DESCRIPTION
In this PR, we made so much solution to resolved problem from typo error as params,
with a clean route path as simple to write with a function instead of trying to thing   how to write each link to feat the need.

[FIX] fixing type 'false' instead of 'fals']
closes #173 

[FIX] resolve try to access parentNode of undefined]
closes #174 

[ENH] get formatted route path via function]
closes #175 