### PR TITLE
[ENH] refactor http input to trigger each specific action, from GET, POST, PUT and FILES

### DIFF
--- a/controller/exampleController.php
+++ b/controller/exampleController.php
@@ -36,7 +36,7 @@ class exampleController extends Controller
      */
     function changeLang(): void
     {
-        Session::put('lang', Input::get("lang"));
+        Session::put('lang', Input::post("lang"));
         Redirect::to("/");
     }
 }

--- a/middleware/Validation/exampleValidation.php
+++ b/middleware/Validation/exampleValidation.php
@@ -11,7 +11,7 @@ class exampleValidation extends MiddleWare
         $schema = [
             "token" => $this->rule->string("token")
                 ->min(5)
-                ->max(30)
+                ->max(50)
                 ->required(),
             "lang" => $this->rule->string("lang")
                 ->min(1)

--- a/src/Core/Http/Input.php
+++ b/src/Core/Http/Input.php
@@ -7,10 +7,11 @@ namespace Wepesi\Core\Http;
 class Input
 {
     /**
+     * check if the submission form is a port action
      * @param $type
      * @return bool
      */
-    public static function exists($type = "POST")
+    public static function exists($type = "POST"): bool
     {
         switch ($type) {
             case "POST":
@@ -41,51 +42,46 @@ class Input
     }
 
     /**
+     * extract data from submit form as form data
      * @param $file_input
-     * @return array|string[]
+     * @return array
      */
-    private static function extractFromFormData($file_input)
+    private static function extractFromFormData($file_input): array
     {
-        $fragma = [];
+        $form_data_fragmentation = [];
         $explode = explode("\r", implode("\r", explode("\n", $file_input)));
         $len_Arr = count($explode);
         for ($i = 1; $i < $len_Arr; $i++) {
             if (!strchr($explode[$i], "----------------------------")) {
                 if (strlen($explode[$i]) > 0) {
                     $replaced = str_replace("Content-Disposition: form-data; name=", "", $explode[$i]);
-                    array_push($fragma, $replaced);
+                    $form_data_fragmentation[] = $replaced;
                 }
             }
         }
-        $len_object = count($fragma);
+        $len_object = count($form_data_fragmentation);
         $object = [];
         for ($j = 0; $j < $len_object; $j++) {
             if ($j == 0 || ($j + 1) % 2 != 0) {
-                $key = str_replace("\"", "", $fragma[$j]);
-                $object = array_merge($object, [$key => trim($fragma[($j + 1)])]);
+                $key = str_replace("\"", "", $form_data_fragmentation[$j]);
+                $object = array_merge($object, [$key => trim($form_data_fragmentation[($j + 1)])]);
             }
         }
         return $object;
     }
 
     /**
+     * Access data information from $_GET action of url request
      * @param $item
      * @return mixed|null
      */
     static function get($item)
     {
-        $object_data = self::put();
-        if (isset($_POST[$item])) {
-            return $_POST[$item];
-        } else if (isset($_GET[$item])) {
-            return $_GET[$item];
-        } else if (isset($object_data[$item])) {
-            return $object_data[$item];
-        }
-        return null;
+        return $_GET[$item] ?? null;
     }
 
     /**
+     * Access HEADER data information from header
      * Extract header data information
      * @param $item
      * @return mixed|null
@@ -100,10 +96,35 @@ class Input
     }
 
     /**
-     * @return array|null
+     * Lists params submitted via POST, PATCH or PUT action event
+     * @return array
      */
-    public static function body()
+    public static function body(): ?array
     {
-        return isset($_POST) && !empty($_POST) ? $_POST : !empty(self::put() ? self::put() : null);
+        return !empty($_POST) ? $_POST : (!empty(self::put()) ? self::put() : null);
+    }
+
+    /**
+     * Access data information from POST or PUT action event
+     * @param $item
+     * @return mixed|string|null
+     */
+    public static function post($item){
+        $self_put = self::put();
+        if (isset($_POST[$item])) {
+            return $_POST[$item];
+        } else if (isset($self_put[$item])) {
+            return $self_put[$item];
+        }
+        return null;
+    }
+
+    /**
+     * Access data information from file upload event
+     * @param string $item
+     * @return mixed|null
+     */
+    public static function file(string $item) {
+        return $_FILES[$item] ?? null;
     }
 }


### PR DESCRIPTION
We used to used `Input::get()` method to read data from http request `GET` , `POST` and `PUT` without any distinction, that lead for some confusion, in case we want to deal with post, put, there was not a specific way to deal with.
The approach to have each method for a specific case it makes the module more readable and more mature, and void confusion.
closes #205