### PR TITLE
[FIX] Restrict global variable to access users data

### DIFF
--- a/src/Core/DotEnv.php
+++ b/src/Core/DotEnv.php
@@ -48,7 +48,6 @@ class DotEnv
             if (!array_key_exists($name, $_SERVER) && !array_key_exists($name, $_ENV)) {
                 putenv(sprintf('%s=%s', $name, $value));
                 $_ENV[$name] = $value;
-                $_SERVER[$name] = $value;
             }
         }
     }


### PR DESCRIPTION
it was possible to access user data via global variable, that required to be removed.
closes #180 