### PR TITLE
[ENG]Introduce the DI on support

### DIFF
--- a/app/Middleware/exampleValidation.php
+++ b/app/Middleware/exampleValidation.php
@@ -24,7 +24,7 @@ class exampleValidation extends MiddleWare
 
         $this->validate->check($_POST, $schema);
         if (!$this->validate->passed()) {
-            print_r($this->validate->errors());
+            print_r($this->validate->getErrors());
         }
     }
 }

--- a/app/Middleware/exampleValidation.php
+++ b/app/Middleware/exampleValidation.php
@@ -5,11 +5,15 @@
 
 namespace App\Middleware;
 
+use Wepesi\Core\Exceptions\ValidationException;
 use Wepesi\Core\Http\MiddleWare;
 
 class exampleValidation extends MiddleWare
 {
-    function changeLang()
+    /**
+     * @throws ValidationException
+     */
+    function changeLang(): void
     {
         $schema = [
             "token" => $this->rule->string("token")
@@ -17,6 +21,7 @@ class exampleValidation extends MiddleWare
                 ->max(50)
                 ->required(),
             "lang" => $this->rule->string("lang")
+                ->unique("languages")
                 ->min(1)
                 ->max(2)
                 ->required()

--- a/config/services.php
+++ b/config/services.php
@@ -1,0 +1,12 @@
+<?php
+/*
+ * Copyright (c) 2026. Wepesi Dev Framework
+ */
+
+return static function (): void {
+    // Application::bind(SomeInterface::class, SomeImplementation::class);
+
+    // Application::singleton(SomeService::class, function () {
+    //     return new SomeService();
+    // });
+};

--- a/index.php
+++ b/index.php
@@ -6,6 +6,7 @@
 
 use Wepesi\Core\AppConfiguration;
 use Wepesi\Core\Application;
+use Wepesi\Core\DI\Container;
 use Wepesi\Core\DotEnv;
 
 // Define root directory
@@ -23,6 +24,7 @@ require_once $ROOT_DIR . '/config/init.php';
 if (getenv('APP_ENV') === 'prod') {
     autoIndexFolder(['assets']);
 }
+$container = new Container();
 
 $appConfiguration = new AppConfiguration();
 
@@ -32,6 +34,6 @@ $configuration = $appConfiguration
     ->lang(getenv('LANG'))
     ->timezone(getenv('TIME_ZONE'));
 
-$app = new Application($ROOT_DIR, $configuration);
+$app = new Application($ROOT_DIR, $configuration, $container);
 
 $app->run();

--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -5,8 +5,24 @@
 
 namespace Wepesi\Core;
 
+use Wepesi\Core\Database\Database;
 use Wepesi\Core\Database\DatabaseConfig;
+use Wepesi\Core\Database\Providers\Contracts\DatabaseContracts;
+use Wepesi\Core\DI\Container;
+use Wepesi\Core\DI\Contracts\ContainerContracts;
+use Wepesi\Core\Http\Input;
+use Wepesi\Core\Http\Redirect;
+use Wepesi\Core\Http\Request;
+use Wepesi\Core\Http\Response;
+use Wepesi\Core\Resolver\Option;
+use Wepesi\Core\Resolver\OptionsResolver;
+use Wepesi\Core\Routing\Route;
+use Wepesi\Core\Routing\RouteFileRegistrar;
 use Wepesi\Core\Routing\Router;
+use Wepesi\Core\Validation\MessageErrorBuilder;
+use Wepesi\Core\Validation\Providers\Contracts\MessageBuilderContracts;
+use Wepesi\Core\Validation\Validate;
+use Wepesi\Core\View\View;
 
 /**
  *
@@ -24,10 +40,16 @@ class Application
     private static string $APP_ROUTE_PATH;
 
     /**
+     * @var ContainerContracts
+     */
+    private static ContainerContracts $container;
+
+    /**
      * define application global configuration
      * @var string
      */
     private static string $root_dir;
+
     /**
      * @var string
      */
@@ -58,8 +80,9 @@ class Application
      * Application constructor.
      * @param string $path root path directory of the application
      * @param AppConfiguration $config
+     * @param ContainerContracts $Container
      */
-    public function __construct(string $path, AppConfiguration $config)
+    public function __construct(string $path, AppConfiguration $config, ContainerContracts $Container)
     {
         $config_params = $config->getCongigurations();
         self::$root_dir = str_replace("\\", '/', $path);
@@ -70,9 +93,83 @@ class Application
         self::$layout = '';
         self::$APP_VIEW_PATH = $config_params['view'];
         self::$APP_ROUTE_PATH = $config_params['route'];
-        $this->router = new Router();
+        //
+        self::$container = $Container;
+
+        self::$container->instance(self::class, $this);
+        self::$container->instance(Container::class, self::$container);
+
+        $this->registerCoreServices();
+        $this->loadServiceProviders();
+
+        $this->router = self::$container->get(Router::class);
     }
 
+    /**
+     * Get the application dependency injection container.
+     *
+     * @return ContainerContracts
+     */
+    public static function container(): ContainerContracts
+    {
+        return self::$container;
+    }
+
+    /**
+     * Resolve a service from the application container.
+     *
+     * @param string $abstract
+     * @param array<int|string, mixed> $parameters
+     * @return mixed
+     */
+    public static function make(string $abstract, array $parameters = []): mixed
+    {
+        return self::$container->get($abstract, $parameters);
+    }
+
+    /**
+     * Register a service in the application container.
+     *
+     * @param string $abstract
+     * @param callable|string|null $concrete
+     * @return void
+     */
+    public static function bind(string $abstract, callable|string|null $concrete = null): void
+    {
+        self::$container->bind($abstract, $concrete);
+    }
+
+    /**
+     * Register a singleton service in the application container.
+     *
+     * @param string $abstract
+     * @param callable|string|null $concrete
+     * @return void
+     */
+    public static function singleton(string $abstract, callable|string|null $concrete = null): void
+    {
+        self::$container->singleton($abstract, $concrete);
+    }
+
+    /**
+     * Load application service bindings.
+     *
+     * @return void
+     */
+    private function loadServiceProviders(): void
+    {
+        $serviceConfigPath = self::$root_dir . '/config/services.php';
+
+        if (!file_exists($serviceConfigPath)) {
+            return;
+        }
+
+        $provider = require $serviceConfigPath;
+
+        if (is_callable($provider)) {
+            $provider();
+        }
+    }
     /**
      * @return string
      */
@@ -80,6 +177,8 @@ class Application
     {
         return self::$root_dir . self::$APP_VIEW_PATH;
     }
+
+
 
     /**
      * @return string
@@ -179,7 +278,7 @@ class Application
      */
     private function initDB(): void
     {
-        (new DatabaseConfig())
+        self::$container->get(DatabaseConfig::class)
             ->host($_ENV['DB_HOST'])
             ->port($_ENV['DB_PORT'])
             ->db($_ENV['DB_NAME'])
@@ -195,5 +294,78 @@ class Application
         $this->initDB();
         $this->routeProvider();
         $this->router->run();
+    }
+
+    /**
+     * Register framework core services in the dependency injection container.
+     *
+     * @return void
+     */
+    private function registerCoreServices(): void
+    {
+        self::$container->instance(self::class, $this);
+        self::$container->instance(ContainerContracts::class, self::$container);
+        self::$container->instance(Container::class, self::$container);
+
+        /*
+         * Core application services.
+         */
+        self::$container->singleton(Router::class);
+        self::$container->singleton(DatabaseConfig::class);
+
+        /*
+         * Database uses a private constructor, so it must be registered through getInstance().
+         */
+        self::$container->singleton(Database::class, function () {
+            return Database::getInstance();
+        });
+
+        self::$container->singleton(DatabaseContracts::class, function () {
+            return Database::getInstance();
+        });
+
+        /*
+         * Route-related classes receive runtime constructor parameters.
+         * They must be bind(), not singleton().
+         */
+        self::$container->bind(Route::class);
+        self::$container->bind(RouteFileRegistrar::class);
+
+        /*
+        * Resolver classes receive runtime parameters.
+        */
+        self::$container->bind(Option::class);
+        self::$container->bind(OptionsResolver::class);
+
+        /*
+         * HTTP services.
+         */
+        self::$container->singleton(Request::class);
+        self::$container->singleton(Response::class);
+        self::$container->singleton(Input::class);
+        self::$container->singleton(Redirect::class);
+
+        /*
+         * View and validation services.
+         */
+        self::$container->singleton(View::class);
+        self::$container->singleton(Validate::class);
+        self::$container->singleton(MessageErrorBuilder::class);
+        self::$container->bind(MessageBuilderContracts::class, MessageErrorBuilder::class);
+
+        /*
+         * Utility services.
+         */
+        self::$container->singleton(Config::class);
+        self::$container->singleton(DotEnv::class);
+        self::$container->singleton(Hash::class);
+        self::$container->singleton(I18n::class);
+        self::$container->singleton(Session::class);
+        self::$container->singleton(Token::class);
+        self::$container->singleton(JWT::class);
+        self::$container->singleton(Email::class);
+        self::$container->singleton(Media::class);
+        self::$container->singleton(MetaData::class);
+        self::$container->singleton(Bundles::class);
     }
 }

--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -8,6 +8,10 @@ namespace Wepesi\Core;
 use Wepesi\Core\Database\Database;
 use Wepesi\Core\Database\DatabaseConfig;
 use Wepesi\Core\Database\Providers\Contracts\DatabaseContracts;
+use Wepesi\Core\Database\Providers\Contracts\WhereBuilderContracts;
+use Wepesi\Core\Database\Providers\Contracts\WhereConditionContracts;
+use Wepesi\Core\Database\WhereQueryBuilder\WhereBuilder;
+use Wepesi\Core\Database\WhereQueryBuilder\WhereConditions;
 use Wepesi\Core\DI\Container;
 use Wepesi\Core\DI\Contracts\ContainerContracts;
 use Wepesi\Core\Http\Input;
@@ -326,6 +330,14 @@ class Application
         });
 
         /*
+         * Database query builder services.
+         */
+        self::$container->bind(WhereBuilder::class);
+        self::$container->bind(WhereBuilderContracts::class, WhereBuilder::class);
+        self::$container->bind(WhereConditions::class);
+        self::$container->bind(WhereConditionContracts::class, WhereConditions::class);
+
+        /*
          * Route-related classes receive runtime constructor parameters.
          * They must be bind(), not singleton().
          */
@@ -355,7 +367,7 @@ class Application
          */
         self::$container->singleton(View::class);
         self::$container->bind(ViewEngineContracts::class, View::class);
-        self::$container->singleton(Validate::class);
+        self::$container->bind(Validate::class);
         self::$container->singleton(MessageErrorBuilder::class);
 
         /*

--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -22,6 +22,7 @@ use Wepesi\Core\Routing\Router;
 use Wepesi\Core\Validation\MessageErrorBuilder;
 use Wepesi\Core\Validation\Providers\Contracts\MessageBuilderContracts;
 use Wepesi\Core\Validation\Validate;
+use Wepesi\Core\View\Provider\Contract\ViewEngineContracts;
 use Wepesi\Core\View\View;
 
 /**
@@ -337,10 +338,14 @@ class Application
         self::$container->bind(Option::class);
         self::$container->bind(OptionsResolver::class);
 
+
+        self::$container->bind(MessageBuilderContracts::class, MessageErrorBuilder::class);
         /*
          * HTTP services.
          */
-        self::$container->singleton(Request::class);
+        self::$container->singleton(Request::class, function () {
+            return Request::createFromGlobals();
+        });
         self::$container->singleton(Response::class);
         self::$container->singleton(Input::class);
         self::$container->singleton(Redirect::class);
@@ -349,9 +354,9 @@ class Application
          * View and validation services.
          */
         self::$container->singleton(View::class);
+        self::$container->bind(ViewEngineContracts::class, View::class);
         self::$container->singleton(Validate::class);
         self::$container->singleton(MessageErrorBuilder::class);
-        self::$container->bind(MessageBuilderContracts::class, MessageErrorBuilder::class);
 
         /*
          * Utility services.

--- a/src/Core/DI/Container.php
+++ b/src/Core/DI/Container.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace Wepesi\Core\DI;
+
+use Closure;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionFunction;
+use ReflectionMethod;
+use ReflectionNamedType;
+use Wepesi\Core\DI\Contracts\ContainerContracts;
+
+class Container implements ContainerContracts
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $bindings = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $instances = [];
+
+    /**
+     * @var array<int, string>
+     */
+    private array $resolutionStack = [];
+
+    /**
+     * Register a service factory or implementation.
+     *
+     * @param string $abstract
+     * @param Closure|string|null $concrete
+     * @return void
+     */
+    public function bind(string $abstract, Closure|string|null $concrete = null): void
+    {
+        $this->bindings[$abstract] = $concrete ?? $abstract;
+    }
+
+    /**
+     * Register a shared singleton service.
+     *
+     * @param string $abstract
+     * @param Closure|string|null $concrete
+     *
+     * @return void
+     */
+    public function singleton(string $abstract, Closure|string|null $concrete = null): void
+    {
+        $this->bindings[$abstract] = function (ContainerContracts $container, array $parameters = []) use ($abstract, $concrete) {
+            if (!isset($this->instances[$abstract])) {
+                $this->instances[$abstract] = $container->build($concrete ?? $abstract, $parameters);
+            }
+
+            return $this->instances[$abstract];
+        };
+    }
+
+    /**
+     * Register an already-created instance.
+     *
+     * @param string $abstract
+     * @param mixed $instance
+     * @return void
+     */
+    public function instance(string $abstract, mixed $instance): void
+    {
+        $this->instances[$abstract] = $instance;
+    }
+
+    /**
+     * Resolve a service from the container.
+     *
+     * @template T
+     * @param class-string<T>|string $abstract
+     * @param array<int|string, mixed> $parameters
+     *
+     * @return T|mixed
+     */
+    public function get(string $abstract, array $parameters = []): mixed
+    {
+        if (empty($parameters) && isset($this->instances[$abstract])) {
+            return $this->instances[$abstract];
+        }
+
+        if (!isset($this->bindings[$abstract])) {
+            return $this->build($abstract, $parameters);
+        }
+
+        $concrete = $this->bindings[$abstract];
+
+        if ($concrete instanceof Closure) {
+            return $concrete($this, $parameters);
+        }
+
+        return $this->build($concrete, $parameters);
+    }
+
+    /**
+     * Alias for get().
+     *
+     * @param string $abstract
+     * @param array<int|string, mixed> $parameters
+     *
+     * @return mixed
+     */
+    public function make(string $abstract, array $parameters = []): mixed
+    {
+        return $this->get($abstract, $parameters);
+    }
+
+    /**
+     * Check if a service has been registered.
+     *
+     * @param string $abstract
+     * @return bool
+     */
+    public function has(string $abstract): bool
+    {
+        return isset($this->bindings[$abstract]) || isset($this->instances[$abstract]);
+    }
+
+    /**
+     * Build an object using reflection and constructor injection.
+     *
+     * @param Closure|string $concrete
+     * @param array<int|string, mixed> $parameters
+     *
+     * @return mixed
+     */
+    public function build(Closure|string $concrete, array $parameters = []): mixed
+    {
+        if ($concrete instanceof Closure) {
+            return $concrete($this, $parameters);
+        }
+
+        $this->guardAgainstCircularDependency($concrete);
+        $this->resolutionStack[] = $concrete;
+
+        if (!class_exists($concrete)) {
+            throw new ContainerException("Class [$concrete] does not exist.");
+        }
+        try {
+
+
+            try {
+                $reflection = new ReflectionClass($concrete);
+            } catch (ReflectionException $exception) {
+                throw new ContainerException($exception->getMessage(), 0, $exception);
+            }
+
+            if (!$reflection->isInstantiable()) {
+                throw new ContainerException("Class [$concrete] is not instantiable.");
+            }
+
+            $constructor = $reflection->getConstructor();
+
+            if ($constructor === null) {
+                $instance = new $concrete();
+
+                $this->initializeInstance($instance);
+
+                return $instance;
+            }
+
+            $dependencies = $this->resolveDependencies(
+                $constructor->getParameters(),
+                $parameters,
+                $concrete
+            );
+
+            $instance = $reflection->newInstanceArgs($dependencies);
+
+            $this->initializeInstance($instance);
+
+            return $instance;
+
+        } finally {
+            array_pop($this->resolutionStack);
+        }
+    }
+
+    /**
+     * Initialize a newly created object if it supports framework initialization.
+     *
+     * @param object $instance
+     * @return void
+     */
+    private function initializeInstance(object $instance): void
+    {
+        if (method_exists($instance, '__wepesiInit')) {
+            $instance->__wepesiInit();
+        }
+    }
+
+    /**
+     * Call a callable while resolving class-typed parameters.
+     *
+     * @param callable|array|string $callable
+     * @param array<int|string, mixed> $parameters
+     * @return mixed
+     */
+    public function call(callable|array|string $callable, array $parameters = []): mixed
+    {
+        if (is_string($callable) && str_contains($callable, '#')) {
+            [$class, $method] = explode('#', $callable, 2);
+            $callable = [$this->get($class), $method];
+        }
+
+        if (is_array($callable) && is_string($callable[0])) {
+            $callable[0] = $this->get($callable[0]);
+        }
+
+        if (!is_callable($callable)) {
+            throw new ContainerException('The provided value is not callable.');
+        }
+
+        try {
+            $reflection = is_array($callable)
+                ? new ReflectionMethod($callable[0], $callable[1])
+                : new ReflectionFunction($callable);
+        } catch (ReflectionException $exception) {
+            throw new ContainerException($exception->getMessage(), 0, $exception);
+        }
+
+        $dependencies = $this->resolveDependencies(
+            $reflection->getParameters(),
+            $parameters
+        );
+
+        return call_user_func_array($callable, $dependencies);
+    }
+
+    /**
+     * Resolve constructor, function, or method dependencies.
+     *
+     * @param array<int, \ReflectionParameter> $reflectionParameters
+     * @param array<int|string, mixed> $parameters
+     * @param string|null $concrete
+     * @return array<int, mixed>
+     */
+    private function resolveDependencies(array $reflectionParameters, array $parameters = [], ?string $concrete = null): array
+    {
+        $dependencies = [];
+
+        foreach ($reflectionParameters as $index => $parameter) {
+            if (array_key_exists($parameter->getName(), $parameters)) {
+                $dependencies[] = $parameters[$parameter->getName()];
+                continue;
+            }
+
+            if (array_key_exists($index, $parameters)) {
+                $dependencies[] = $parameters[$index];
+                continue;
+            }
+
+            $type = $parameter->getType();
+
+            if ($type instanceof ReflectionNamedType && !$type->isBuiltin()) {
+                $dependencies[] = $this->get($type->getName());
+                continue;
+            }
+
+            if ($parameter->isDefaultValueAvailable()) {
+                $dependencies[] = $parameter->getDefaultValue();
+                continue;
+            }
+
+            $target = $concrete ? " for class [$concrete]" : '';
+
+            throw new ContainerException(
+                "Unable to resolve parameter [{$parameter->getName()}]$target."
+            );
+        }
+
+        return $dependencies;
+    }
+
+    /**
+     * Detect circular dependencies before resolving a class.
+     *
+     * @param string $concrete
+     * @return void
+     */
+    private function guardAgainstCircularDependency(string $concrete): void
+    {
+        if (!in_array($concrete, $this->resolutionStack, true)) {
+            return;
+        }
+
+        $cycle = array_merge(
+            array_slice(
+                $this->resolutionStack,
+                array_search($concrete, $this->resolutionStack, true)
+            ),
+            [$concrete]
+        );
+
+        throw new ContainerException(
+            'Circular dependency detected: ' . implode(' -> ', $cycle)
+        );
+    }
+}

--- a/src/Core/DI/ContainerException.php
+++ b/src/Core/DI/ContainerException.php
@@ -1,0 +1,13 @@
+<?php
+/*
+ * Copyright (c) 2026. Wepesi Dev Framework
+ */
+
+namespace Wepesi\Core\DI;
+
+use RuntimeException;
+
+class ContainerException extends RuntimeException
+{
+
+}

--- a/src/Core/DI/Contracts/ContainerContracts.php
+++ b/src/Core/DI/Contracts/ContainerContracts.php
@@ -1,0 +1,116 @@
+<?php
+/*
+ * Copyright (c) 2026. Wepesi Dev Framework
+ */
+
+namespace Wepesi\Core\DI\Contracts;
+
+use Closure;
+
+interface ContainerContracts
+{
+    /**
+     * Register a binding in the container.
+     *
+     * A binding maps an abstract type or identifier to a concrete implementation.
+     * The concrete value may be a class name, a factory closure, or null. When null
+     * is provided, the abstract type is used as the concrete implementation.
+     *
+     * @param string $abstract The abstract type, interface, class name, or service identifier.
+     * @param Closure|string|null $concrete The concrete implementation or factory closure.
+     *
+     * @return void
+     */
+    public function bind(string $abstract, Closure|string|null $concrete = null): void;
+
+    /**
+     * Register a shared binding in the container.
+     *
+     * A singleton binding is resolved only once. The same resolved instance will be
+     * returned every time the abstract type is requested from the container.
+     *
+     * @param string $abstract The abstract type, interface, class name, or service identifier.
+     * @param Closure|string|null $concrete The concrete implementation or factory closure.
+     *
+     * @return void
+     */
+    public function singleton(string $abstract, Closure|string|null $concrete = null): void;
+
+    /**
+     * Register an existing instance in the container.
+     *
+     * The provided instance will be stored directly and returned whenever the
+     * abstract type is requested.
+     *
+     * @param string $abstract The abstract type, interface, class name, or service identifier.
+     * @param mixed $instance The already-created instance to store in the container.
+     *
+     * @return void
+     */
+    public function instance(string $abstract, mixed $instance): void;
+
+    /**
+     * Resolve an abstract type from the container.
+     *
+     * This method retrieves the concrete instance associated with the given
+     * abstract type or service identifier.
+     *
+     * @param string $abstract The abstract type, interface, class name, or service identifier.
+     * @param array<int|string, mixed> $parameters
+     *
+     * @return mixed The resolved service instance.
+     */
+    public function get(string $abstract, array $parameters = []): mixed;
+
+    /**
+     * Resolve an abstract type from the container.
+     *
+     * This method creates or retrieves an instance for the given abstract type.
+     * If the type has been registered as a singleton or instance, the shared
+     * instance should be returned.
+     *
+     * @param string $abstract The abstract type, interface, class name, or service identifier.
+     * @param array<int|string, mixed> $parameters
+     *
+     * @return mixed The resolved service instance.
+     */
+    public function make(string $abstract, array $parameters = []): mixed;
+
+    /**
+     * Determine whether an abstract type is registered in the container.
+     *
+     * This checks if the container has a binding, singleton, or instance registered
+     * for the given abstract type or service identifier.
+     *
+     * @param string $abstract The abstract type, interface, class name, or service identifier.
+     *
+     * @return bool True if the abstract type is registered, false otherwise.
+     */
+    public function has(string $abstract): bool;
+
+    /**
+     * Build a concrete implementation.
+     *
+     * The concrete value may be a class name or a factory closure. If a closure is
+     * provided, it should be executed to produce the instance. If a class name is
+     * provided, the container should attempt to instantiate it.
+     *
+     * @param Closure|string $concrete The concrete class name or factory closure to build.
+     * @param array<int|string, mixed> $parameters
+     *
+     * @return mixed The built instance or resolved value.
+     */
+
+    public function build(Closure|string $concrete, array $parameters = []): mixed;
+
+    /**
+     * Call a callable while resolving class-typed parameters.
+     *
+     * @param callable|array|string $callable
+     * @param array<int|string, mixed> $parameters
+     *
+     * @return mixed
+     */
+
+    public function call(callable|array|string $callable, array $parameters = []): mixed;
+}

--- a/src/Core/Email.php
+++ b/src/Core/Email.php
@@ -2,6 +2,9 @@
 
 namespace Wepesi\Core;
 
+use Exception;
+use Wepesi\Core\Validation\Validate;
+
 class Email
 {
     private $url;
@@ -55,7 +58,7 @@ class Email
         try {
             $body = $this->template($body);
             return $this->sendMail($data, $body);
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             return ["exception" => $ex->getMessage()];
         }
     }
@@ -132,7 +135,7 @@ class Email
             </body>
             </html>
         html_body;
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             return ["exception" => $ex->getMessage()];
         }
     }
@@ -151,7 +154,7 @@ class Email
                 "From:$this->from"
             ];
             return mail($this->to, $this->subject, $body, implode("\r\n", $header));
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             return ["exception" => $ex->getMessage()];
         }
     }
@@ -162,16 +165,16 @@ class Email
     private function checkConfig(array $config_data)
     {
         try {
-            $validat = new Validate($config_data);
+            $validat = Application::make(Validate::class,$config_data);
             $schema = [
                 "from" => $validat->string("from")->required()->email()->check(),
                 "to" => $validat->string("to")->required()->email()->check(),
             ];
             $validat->check($config_data, $schema);
             if (!$validat->passed()) {
-                throw new \Exception($validat->errors());
+                throw new Exception($validat->getErrors());
             }
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             return ["exception" => $ex->getMessage()];
         }
     }

--- a/src/Core/Http/Controller.php
+++ b/src/Core/Http/Controller.php
@@ -21,14 +21,11 @@ abstract class Controller extends BaseControllerMiddleware
      * @var View
      */
     protected ViewEngineContracts $view;
-
     /**
-     *
+     * @var MetaData
      */
-    public function __construct()
-    {
-        $this->view = new View();
-    }
+    private MetaData $metadata;
+
     /**
      * Framework service initializer.
      *
@@ -40,7 +37,6 @@ abstract class Controller extends BaseControllerMiddleware
     final public function __wepesiInit(): void
     {
         $this->view = Application::make(ViewEngineContracts::class);
-        $this->media = Application::make(Media::class);
         $this->metadata = Application::make(MetaData::class);
     }
 }

--- a/src/Core/Http/Controller.php
+++ b/src/Core/Http/Controller.php
@@ -27,7 +27,6 @@ abstract class Controller extends BaseControllerMiddleware
      */
     public function __construct()
     {
-        parent::__construct();
         $this->view = new View();
     }
     /**

--- a/src/Core/Http/Controller.php
+++ b/src/Core/Http/Controller.php
@@ -5,7 +5,10 @@
 
 namespace Wepesi\Core\Http;
 
+use Wepesi\Core\Application;
 use Wepesi\Core\Http\Providers\BaseControllerMiddleware;
+use Wepesi\Core\Media;
+use Wepesi\Core\MetaData;
 use Wepesi\Core\View\Provider\Contract\ViewEngineContracts;
 use Wepesi\Core\View\View;
 
@@ -26,5 +29,19 @@ abstract class Controller extends BaseControllerMiddleware
     {
         parent::__construct();
         $this->view = new View();
+    }
+    /**
+     * Framework service initializer.
+     *
+     * This method is called automatically by the DI container after the controller
+     * is created, so child controllers do not need to call parent::__construct().
+     *
+     * @return void
+     */
+    final public function __wepesiInit(): void
+    {
+        $this->view = Application::make(ViewEngineContracts::class);
+        $this->media = Application::make(Media::class);
+        $this->metadata = Application::make(MetaData::class);
     }
 }

--- a/src/Core/Http/MiddleWare.php
+++ b/src/Core/Http/MiddleWare.php
@@ -5,6 +5,7 @@
 
 namespace Wepesi\Core\Http;
 
+use Wepesi\Core\Application;
 use Wepesi\Core\Http\Providers\BaseControllerMiddleware;
 use Wepesi\Core\Validation\Rules;
 use Wepesi\Core\Validation\Validate;
@@ -14,10 +15,21 @@ abstract class MiddleWare extends BaseControllerMiddleware
     protected Validate $validate;
     protected Rules $rule;
 
-    public function __construct()
+    /**
+     * Framework service initializer.
+     *
+     * This method is called automatically by the DI container after the middleware
+     * is created, so child middleware classes do not need to call parent::__construct().
+     *
+     * @return void
+     */
+    final public function __wepesiInit(): void
     {
-        parent::__construct();
-        $this->rule = new Rules();
-        $this->validate = new Validate();
+        // Initialize base services
+        $this->initializeBaseServices();
+        //
+
+        $this->validate = Application::make(Validate::class);
+        $this->rule = Application::make(Rules::class);
     }
 }

--- a/src/Core/Http/Providers/BaseControllerMiddleware.php
+++ b/src/Core/Http/Providers/BaseControllerMiddleware.php
@@ -5,7 +5,11 @@
 
 namespace Wepesi\Core\Http\Providers;
 
+use Wepesi\Core\Application;
+use Wepesi\Core\Http\Request;
+use Wepesi\Core\Http\Response;
 use Wepesi\Core\Media;
+use Wepesi\Core\Session;
 
 /**
  *
@@ -16,12 +20,15 @@ abstract class BaseControllerMiddleware
      * @var Media
      */
     protected Media $media;
+    protected Request $request;
+    protected Response $response;
+    protected Session $session;
 
-    /**
-     *
-     */
-    public function __construct()
+    protected function initializeBaseServices(): void
     {
-        $this->media = new Media();
+        $this->media = Application::make(Media::class);
+        $this->request = Application::make(Request::class);
+        $this->response = Application::make(Response::class);
+        $this->session = Application::make(Session::class);
     }
 }

--- a/src/Core/Http/Providers/BaseControllerMiddleware.php
+++ b/src/Core/Http/Providers/BaseControllerMiddleware.php
@@ -6,6 +6,10 @@
 namespace Wepesi\Core\Http\Providers;
 
 use Wepesi\Core\Application;
+use Wepesi\Core\Database\Providers\Contracts\WhereBuilderContracts;
+use Wepesi\Core\Database\Providers\Contracts\WhereConditionContracts;
+use Wepesi\Core\Database\WhereQueryBuilder\WhereBuilder;
+use Wepesi\Core\Database\WhereQueryBuilder\WhereConditions;
 use Wepesi\Core\Http\Request;
 use Wepesi\Core\Http\Response;
 use Wepesi\Core\Media;
@@ -20,15 +24,37 @@ abstract class BaseControllerMiddleware
      * @var Media
      */
     protected Media $media;
+    /**
+     * @var Request
+     */
     protected Request $request;
+    /**
+     * @var Response
+     */
     protected Response $response;
+    /**
+     * @var Session
+     */
     protected Session $session;
+    /**
+     * @var WhereBuilderContracts
+     */
+    protected WhereBuilderContracts $whereBuilder;
+    /**
+     * @var WhereConditionContracts
+     */
+    protected WhereConditionContracts $whereCondition;
 
+    /**
+     * @return void
+     */
     protected function initializeBaseServices(): void
     {
         $this->media = Application::make(Media::class);
         $this->request = Application::make(Request::class);
         $this->response = Application::make(Response::class);
         $this->session = Application::make(Session::class);
+        // Entity Manager
+        $this->whereBuilder = Application::make(WhereBuilder::class);
     }
 }

--- a/src/Core/Http/Redirect.php
+++ b/src/Core/Http/Redirect.php
@@ -2,6 +2,7 @@
 
 namespace Wepesi\Core\Http;
 
+use Wepesi\Core\Application;
 use Wepesi\Core\Escape;
 use Wepesi\Core\Validation\Rules;
 use Wepesi\Core\Validation\Validate;
@@ -17,8 +18,8 @@ class Redirect
      */
     static public function to(string $location = '')
     {
-        $rule = new Rules();
-        $validate = new Validate();
+        $rule = Application::make(Rules::class);
+        $validate = Application::make(Validate::class);
         $schema = ['link' => $rule->string()->url()];
         $source = ['link' => $location];
         if (strlen(trim($location)) != 0) {

--- a/src/Core/MetaData.php
+++ b/src/Core/MetaData.php
@@ -3,7 +3,6 @@
 
 namespace Wepesi\Core;
 
-
 class MetaData
 {
     private string $_title;
@@ -20,7 +19,7 @@ class MetaData
     /**
      * BundleMetaData constructor.
      */
-    function __construct()
+    public function __construct()
     {
         $this->_title = $_SERVER['SERVER_NAME'] ?? '';
         $this->_description = $this->_title;
@@ -37,7 +36,7 @@ class MetaData
      * @param string $title
      * @return $this
      */
-    function title(string $title): MetaData
+    public function title(string $title): MetaData
     {
         $this->_title = $title;
         return $this;
@@ -48,7 +47,7 @@ class MetaData
      * @param string $lang
      * @return $this
      */
-    function lang(string $lang): MetaData
+    public function lang(string $lang): MetaData
     {
         $this->_lang = $lang;
         return $this;
@@ -59,42 +58,43 @@ class MetaData
      * @param string $cover
      * @return $this
      */
-    function cover(string $cover): MetaData
+    public function cover(string $cover): MetaData
     {
         $this->_cover = $cover;
         return $this;
     }
 
     /**
-     * Author most of time used for twitter
+     * Author most time used for x previously(twitter)
+     *
      * @param string $author
      * @return $this
      */
-    function author(string $author): MetaData
+    public function author(string $author): MetaData
     {
         $this->_author = $author;
         return $this;
     }
 
     /**
-     *A meta description is an HTML element that sums up the content on your web page.
-     * Search engines typically show the meta description in search results below your title tag.
+     * A meta-description is an HTML element that sums up the content on your web page.
+     * Search engines typically show the meta-description in search results below your title tag.
      *
      * @param string $description
      * @return $this
      */
-    function descriptions(string $description): MetaData
+    public function descriptions(string $description): MetaData
     {
         $this->_description = $description;
         return $this;
     }
 
     /**
-     * the type of meta data eg.: article,blog
+     * the type of metadata e.g.: article, blog
      * @param string $type
      * @return $this
      */
-    function type(string $type): MetaData
+    public function type(string $type): MetaData
     {
         $this->_type = $type;
         return $this;
@@ -105,7 +105,7 @@ class MetaData
      * @param string $link
      * @return $this
      */
-    function link(string $link): MetaData
+    public function link(string $link): MetaData
     {
         $this->_link = $link;
         return $this;
@@ -120,7 +120,7 @@ class MetaData
      * 'FOLLOW': The search engine crawler will follow all the links in that webpage,
      * @return $this
      */
-    function follow(): MetaData
+    public function follow(): MetaData
     {
         $this->_tags[] = 'follow';
         $this->_tags = $this->_follow ? array_diff($this->_tags, ['nofollow']) : $this->_tags;
@@ -134,7 +134,7 @@ class MetaData
      * @param $keyword
      * @return MetaData
      */
-    function keyword($keyword): MetaData
+    public function keyword($keyword): MetaData
     {
         if (is_array($keyword)) {
             $this->_keyword = array_filter($keyword, function ($item) {
@@ -150,7 +150,7 @@ class MetaData
      * 'INDEX': The search engine crawler will index the whole webpage.
      * @return $this
      */
-    function index(): MetaData
+    public function index(): MetaData
     {
         $this->_tags[] = 'index';
         $this->_tags = $this->_index ? array_diff($this->_tags, ['noindex']) : $this->_tags;
@@ -163,7 +163,7 @@ class MetaData
      * 'NOFOLLOW': The search engine crawler will NOT follow the page and any links in that webpage.
      * @return $this
      */
-    function nofollow(): MetaData
+    public function nofollow(): MetaData
     {
         $this->_tags[] = 'nofollow';
         $this->_tags = $this->_follow ? array_diff($this->_tags, ['follow']) : $this->_tags;
@@ -173,10 +173,10 @@ class MetaData
     }
 
     /**
-     * 'NOINDEX':The search engine crawler will NOT index that webpages.
+     * 'NOINDEX':The search engine crawler will NOT index that webpage.
      * @return $this
      */
-    function noIndex(): MetaData
+    public function noIndex(): MetaData
     {
         $this->_tags[] = 'noindex';
         $this->_tags = $this->_index ? array_diff($this->_tags, ['index']) : $this->_tags;
@@ -190,21 +190,22 @@ class MetaData
      * By implementing the canonical tag in the code,
      * your website tells search engines that this URL is the main page
      * and that the engines shouldn’t index other pages.
-     * @param string $canonical : https://doctawetu.com
+     * @param string $canonical : https://example.com
      * @return $this
      */
-    function canonical(string $canonical): MetaData
+    public function canonical(string $canonical): MetaData
     {
         $this->_canonical = $canonical;
         return $this;
     }
 
     /**
-     * Get the complete meta data to be displayed
+     * Get the complete metadata to be displayed
      * @return string
      */
     public function build(): string
     {
+        $html = '';
         if ($this->_title && $this->_description) {
             $open_graph_meta = $this->openGraphMeta();
             $twitter_meta = $this->twitterMeta();
@@ -212,7 +213,7 @@ class MetaData
             $canonical_exist = $this->getCanonical();
             $keyword_exist = $this->getKeyWord();
             $author_exist = $this->getAuthor();
-            return <<<META
+            $html =  <<<META
                 <!-- Extra information -->
                 <meta name="mobile-web-app-capable" content="yes" />
                 <meta name="apple-mobile-web-app-title" content="yes" />
@@ -226,6 +227,7 @@ class MetaData
                 $twitter_meta
             META;
         }
+        return $html;
     }
 
     /**
@@ -265,7 +267,7 @@ class MetaData
     }
 
     /**
-     * @return string|null
+     * @return string
      */
     protected function getType(bool $twitter = false): string
     {
@@ -293,7 +295,7 @@ class MetaData
     }
 
     /**
-     * @return string|null
+     * @return string
      */
     protected function getLang(bool $twitter = false): string
     {
@@ -302,7 +304,7 @@ class MetaData
     }
 
     /**
-     * @return string|null
+     * @return string
      */
     protected function getTitle(bool $twitter = false): string
     {
@@ -311,9 +313,9 @@ class MetaData
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    protected function getDescription(bool $twitter = false): ?string
+    protected function getDescription(bool $twitter = false): string
     {
         $destination = $twitter ? 'twitter' : 'og';
         return $this->_description ? "<meta property = \"$destination:description\" content = \"$this->_description\" />" : '';
@@ -347,7 +349,7 @@ class MetaData
     }
 
     /**
-     * @return string|null
+     * @return string
      */
     protected function getCanonical(bool $twitter = false): string
     {
@@ -356,7 +358,7 @@ class MetaData
     }
 
     /**
-     * @return string|null
+     * @return string
      */
     protected function getTags(): string
     {
@@ -365,7 +367,7 @@ class MetaData
     }
 
     /**
-     * @return string|null
+     * @return string
      */
     protected function getKeyWord(): string
     {
@@ -374,9 +376,9 @@ class MetaData
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    protected function getAuthor(): ?string
+    protected function getAuthor(): string
     {
         return $this->_author ? "<meta name=\"author\" content=\"$this->_author\">" : '';
     }

--- a/src/Core/Routing/Router.php
+++ b/src/Core/Routing/Router.php
@@ -82,7 +82,13 @@ class  Router implements RouterContract
     {
         $pattern = $this->baseRoute . Escape::addSlashes(trim($pattern, '/'));
         $pattern = $this->baseRoute ? rtrim($pattern, '/') : $pattern;
-        $route = new Route($pattern, $callable, $this->baseMiddleware);
+
+        $route = Application::make(Route::class, [
+            $pattern,
+            $callable,
+            $this->baseMiddleware
+        ]);
+
         $this->routes[$methode][] = $route;
 
         if ($name == null && is_string($callable)) {
@@ -151,10 +157,11 @@ class  Router implements RouterContract
         $this->baseRoute .= $pattern;
 
         if ($callable instanceof Closure) {
-            call_user_func($callable, $this);
+            Application::container()->call($callable, [$this]);
         } else {
-            (new RouteFileRegistrar($this))->register($callable);
+            Application::make(RouteFileRegistrar::class, [$this])->register($callable);
         }
+
         $this->baseRoute = $cur_base_route;
     }
 
@@ -199,18 +206,15 @@ class  Router implements RouterContract
     /**
      * @param string $name
      * @param array $params
-     * @return \Exception[]|RoutingException[]
+     * @return Mixed
+     * @throws RoutingException
      */
-    public function url(string $name, array $params = [])
+    public function url(string $name, array $params = []): mixed
     {
-        try {
-            if (!isset($this->_nameRoute[$name])) {
-                throw new RoutingException('No route match');
-            }
-            return $this->_nameRoute[$name]->geturl($params);
-        } catch (RoutingException $ex) {
-            return ['RoutingException' => $ex];
+        if (!isset($this->_nameRoute[$name])) {
+            throw new RoutingException('No route match');
         }
+        return $this->_nameRoute[$name]->geturl($params);
     }
 
     /**

--- a/src/Core/Routing/Traits/routeBuilder.php
+++ b/src/Core/Routing/Traits/routeBuilder.php
@@ -5,6 +5,9 @@
 
 namespace Wepesi\Core\Routing\Traits;
 
+use BadMethodCallException;
+use InvalidArgumentException;
+use ReflectionException;
 use Wepesi\Core\Application;
 
 /**
@@ -21,46 +24,42 @@ trait routeBuilder
     protected function routeFunctionCall($callable, array $matches = [], bool $is_middleware = false): void
     {
         $class_element = !$is_middleware ? 'controller' : 'middleware';
-        try {
-            if (is_string($callable) || is_array($callable)) {
-                $callable_params = is_string($callable) ? explode('#', $callable) : $callable;
-                if (count($callable_params) != 2) {
-                    throw new \InvalidArgumentException("Error : on `$class_element` class/method is not well defined");
-                }
-
-                $class_name = $callable_params[0];
-                $class_method_name = $callable_params[1];
-                if (!class_exists($class_name, true)) {
-                    throw new \InvalidArgumentException("$class_name class not defined, not a valid $class_element", 500);
-                }
-
-                $reflection = new \ReflectionClass($class_name);
-                $class_instance = $reflection->newInstance();
-
-                if (!$reflection->isInstance($class_instance)) {
-                    throw new \ReflectionException('Only instantiable class can be used. Not abstract,interface, or trait can be used.');
-                }
-                if (!method_exists($class_instance, $class_method_name)) {
-                    throw new \BadMethodCallException("method : $class_method_name does not belong the class : $class_name.", 500);
-                }
-                call_user_func_array([$class_instance, $class_method_name], $matches);
-            } else if (isset($callable) && is_callable($callable, true)) {
-                call_user_func_array($callable, $matches);
+        if (is_string($callable) || is_array($callable)) {
+            $callable_params = is_string($callable) ? explode('#', $callable) : $callable;
+            if (count($callable_params) != 2) {
+                throw new InvalidArgumentException("Error : on `$class_element` class/method is not well defined");
             }
-            return;
-        } catch (\Exception $ex) {
-            print_r($ex);
+
+            $class_name = $callable_params[0];
+            $class_method_name = $callable_params[1];
+            if (!class_exists($class_name, true)) {
+                throw new InvalidArgumentException("$class_name class not defined, not a valid $class_element", 500);
+            }
+
+            Application::container()->call([$class_name, $class_method_name], $matches);
+        } else if (isset($callable) && is_callable($callable, true)) {
+            Application::container()->call($callable, $matches);
         }
     }
 
+    /**
+     * @param $controller
+     * @param array $matches
+     * @return void
+     */
     protected function executeController($controller, array $matches = []): void
     {
         $this->routeFunctionCall($controller, $matches);
     }
 
-    protected function executeMiddleware($controller, array $matches = []): void
+    /**
+     * @param $middleware
+     * @param array $matches
+     * @return void
+     */
+    protected function executeMiddleware($middleware, array $matches = []): void
     {
-        $this->routeFunctionCall($controller, $matches, true);
+        $this->routeFunctionCall($middleware, $matches, true);
     }
 
 }

--- a/src/Core/Validation/MessageErrorBuilder.php
+++ b/src/Core/Validation/MessageErrorBuilder.php
@@ -81,7 +81,7 @@ final class MessageErrorBuilder implements MessageBuilderContracts
     /**
      * @return array
      */
-    private function generate(): array
+    public function generate(): array
     {
         return $this->items;
     }

--- a/src/Core/Validation/MessageErrorBuilder.php
+++ b/src/Core/Validation/MessageErrorBuilder.php
@@ -32,8 +32,7 @@ final class MessageErrorBuilder implements MessageBuilderContracts
      */
     public function type(string $value): MessageBuilderContracts
     {
-        $this->items['type'] = $value;
-        return $this;
+        return $this->setKeyValue('type', $value);
     }
 
     /**
@@ -42,8 +41,7 @@ final class MessageErrorBuilder implements MessageBuilderContracts
      */
     public function message(string $value): MessageBuilderContracts
     {
-        $this->items['message'] = $value;
-        return $this;
+        return $this->setKeyValue('message', $value);
     }
 
     /**
@@ -53,7 +51,7 @@ final class MessageErrorBuilder implements MessageBuilderContracts
     public function label(string $value): MessageBuilderContracts
     {
         $this->items['label'] = $value;
-        return $this;
+        return $this->setKeyValue('label', $value);
     }
 
     /**
@@ -62,8 +60,7 @@ final class MessageErrorBuilder implements MessageBuilderContracts
      */
     public function limit(string $value): MessageBuilderContracts
     {
-        $this->items['limit'] = $value;
-        return $this;
+        return $this->setKeyValue('limit', $value);
     }
 
     /**
@@ -76,6 +73,12 @@ final class MessageErrorBuilder implements MessageBuilderContracts
         if (method_exists($this, $method)) {
             return call_user_func_array([$this, $method], $arg);
         }
+    }
+
+    private function setKeyValue(string $key, $value): MessageBuilderContracts
+    {
+        $this->items[$key] = $value;
+        return $this;
     }
 
     /**

--- a/src/Core/Validation/Providers/Contracts/RulesValidationContracts.php
+++ b/src/Core/Validation/Providers/Contracts/RulesValidationContracts.php
@@ -14,7 +14,11 @@ interface RulesValidationContracts extends ValidationContracts
 {
 
     /**
-     * @return mixed
+     * Generates validation rules based on the provided configuration.
+     * 1. Generates the validation rules based on the provided configuration.
+     * 2. Returns the generated validation rules.
+     *
+     * @return array
      */
-    public function generate();
+    public function generate(): array;
 }

--- a/src/Core/Validation/Providers/Contracts/ValidationContracts.php
+++ b/src/Core/Validation/Providers/Contracts/ValidationContracts.php
@@ -14,18 +14,19 @@ interface ValidationContracts
 {
     /**
      * @param int $rule
-     * @return mixed
+     *
      */
     public function min(int $rule);
 
     /**
      * @param int $rule
-     * @return mixed
+     *
      */
     public function max(int $rule);
 
     /**
-     * @return mixed
+     * Marks a field or parameter as mandatory.
+     * Ensures that a value must be provided for this specific field or parameter.
      */
     public function required();
 }

--- a/src/Core/Validation/Providers/ValidatorProvider.php
+++ b/src/Core/Validation/Providers/ValidatorProvider.php
@@ -6,6 +6,7 @@
 
 namespace Wepesi\Core\Validation\Providers;
 
+use Wepesi\Core\Application;
 use Wepesi\Core\Validation\MessageErrorBuilder;
 use Wepesi\Core\Validation\Providers\Contracts\MessageBuilderContracts;
 use Wepesi\Core\Validation\Providers\Contracts\ValidateRulesContracts;
@@ -40,28 +41,28 @@ abstract class ValidatorProvider implements ValidateRulesContracts
      *
      */
 
-    function __construct()
+    public function __construct()
     {
         $this->errors = [];
-        $this->messageItem = new MessageErrorBuilder();
+        $this->messageItem = Application::make(MessageErrorBuilder::class);
     }
 
     /**
      * @param int $rule
-     * @return mixed
+     *
      */
     abstract public function min(int $rule);
 
     /**
      * @param int $rule
-     * @return mixed
+     *
      */
     abstract public function max(int $rule);
 
     /**
-     * @return void
+     *
      */
-    public function required()
+    public function required(): void
     {
         if (is_array($this->field_value)) {
             if (count($this->field_value) == 0) {

--- a/src/Core/Validation/Validate.php
+++ b/src/Core/Validation/Validate.php
@@ -6,7 +6,6 @@
 
 namespace Wepesi\Core\Validation;
 
-use ReflectionClass;
 use Wepesi\Core\Application;
 use Wepesi\Core\Exceptions\ValidationException;
 use Wepesi\Core\Http\Response;
@@ -27,80 +26,80 @@ final class Validate
      * @var bool
      */
     private bool $passed;
-    private MessageBuilderContracts $message;
 
     /**
-     * @param MessageBuilderContracts $message
+     * @var MessageBuilderContracts
      */
-    public function __construct(MessageBuilderContracts $message)
+    private MessageBuilderContracts $message;
+
+    public function __construct()
     {
         $this->errors = [];
         $this->passed = false;
-        $this->message = $message;
+        $this->message = Application::make(MessageErrorBuilder::class);
     }
 
     /**
+     * Validate the data source against the schema
+     *
      * @param array $resource data source where the information will be extracted;
      * @param array $schema data schema
+     *
      * @return void
+     * @throws ValidationException
      */
     function check(array $resource, array $schema): void
     {
-        try {
-            $this->errors = [];
-            $option_resolver = [];
-            /**
-             * use of Option resolver to catch all undefined key
-             * on the source data
-             */
-            foreach ($resource as $item => $response) {
-                $option_resolver[] = Application::make(Option::class, [$item]);
-            }
+        $this->errors = [];
+        $option_resolver = [];
+        /**
+         * use of Option resolver to catch all undefined keys
+         * on the source data
+         */
+        foreach ($resource as $item => $response) {
+            $option_resolver[] = Application::make(Option::class, [$item]);
+        }
 
-            $resolver = Application::make(OptionsResolver::class, [$option_resolver]);
-            $options = $resolver->resolve($schema);
-            $exceptions = $options['InvalidArgumentException'] ?? false;
-            if ($exceptions) {
-                $this->message
-                    ->type('object.unknown')
-                    ->message($exceptions->getMessage())
-                    ->label('exception');
-                $this->addError($this->message);
-            } else {
-                foreach ($schema as $item => $rules) {
-                    if (!is_array($rules) && is_object($rules)) {
-                        if (!$rules->generate()) {
-                            throw new ValidationException('This rule is not a valid! method generate does not exist');
-                        }
-                        $rules = $rules->generate();
+        $resolver = Application::make(OptionsResolver::class, [$option_resolver]);
+        $options = $resolver->resolve($schema);
+        $exceptions = $options['InvalidArgumentException'] ?? false;
+        if ($exceptions) {
+            $this->message
+                ->type('object.unknown')
+                ->message($exceptions->getMessage())
+                ->label('exception');
+            $this->addError($this->message);
+        } else {
+            foreach ($schema as $item => $rules) {
+                if (!is_array($rules) && is_object($rules)) {
+                    if (!$rules->generate()) {
+                        Response::setStatusCode(500);
+                        throw new ValidationException('This rule is not a valid! method generate does not exist');
                     }
-                    $class_namespace = array_keys($rules)[0];
-                    if ($class_namespace == 'any') continue;
-                    $validator_class = str_replace('Rules', 'Validator', $class_namespace);
+                    $rules = $rules->generate();
+                }
+                $class_namespace = array_keys($rules)[0];
+                if ($class_namespace == 'any') continue;
+                $validator_class = str_replace('Rules', 'Validator', $class_namespace);
 
-                    $instance = Application::make($validator_class, [
-                        $item,
-                        $resource
-                    ]);
+                $instance = Application::make($validator_class, [
+                    $item,
+                    $resource
+                ]);
 
-                    foreach ($rules[$class_namespace] as $method => $params) {
-                        if (method_exists($instance, $method)) {
-                            Application::container()->call([$instance, $method], [$params]);
-                        }
-                    }
-                    $result = $instance->result();
-                    if (count($result) > 0) {
-                        $this->errors = array_merge($this->errors, $result);
+                foreach ($rules[$class_namespace] as $method => $params) {
+                    if (method_exists($instance, $method)) {
+                        Application::container()->call([$instance, $method], [$params]);
                     }
                 }
-                if (count($this->errors) == 0) {
-                    $this->passed = true;
+                $result = $instance->result();
+                if (count($result) > 0) {
+                    $this->errors = array_merge($this->errors, $result);
                 }
             }
-        } catch (ValidationException $ex) {
-            Response::setStatusCode(500);
-            print_r($ex);
-            exit;
+            if (count($this->errors) == 0) {
+                $this->passed = true;
+            }
         }
     }
 
@@ -119,7 +118,7 @@ final class Validate
      * Get validation errors
      * 1. if the validation passed, the array will be empty
      * 2. if the validation failed, the array will contain the errors
-     * 
+     *
      * @return array
      */
     public function getErrors(): array

--- a/src/Core/Validation/Validate.php
+++ b/src/Core/Validation/Validate.php
@@ -6,6 +6,7 @@
 
 namespace Wepesi\Core\Validation;
 
+use ReflectionClass;
 use Wepesi\Core\Application;
 use Wepesi\Core\Exceptions\ValidationException;
 use Wepesi\Core\Http\Response;
@@ -29,13 +30,13 @@ final class Validate
     private MessageBuilderContracts $message;
 
     /**
-     *
+     * @param MessageBuilderContracts $message
      */
-    function __construct()
+    public function __construct(MessageBuilderContracts $message)
     {
         $this->errors = [];
         $this->passed = false;
-        $this->message = new MessageErrorBuilder();
+        $this->message = $message;
     }
 
     /**
@@ -43,7 +44,7 @@ final class Validate
      * @param array $schema data schema
      * @return void
      */
-    function check(array $resource, array $schema)
+    function check(array $resource, array $schema): void
     {
         try {
             $this->errors = [];
@@ -53,9 +54,10 @@ final class Validate
              * on the source data
              */
             foreach ($resource as $item => $response) {
-                $option_resolver[] = new Option($item);
+                $option_resolver[] = Application::make(Option::class, [$item]);
             }
-            $resolver = new OptionsResolver($option_resolver);
+
+            $resolver = Application::make(OptionsResolver::class, [$option_resolver]);
             $options = $resolver->resolve($schema);
             $exceptions = $options['InvalidArgumentException'] ?? false;
             if ($exceptions) {
@@ -68,20 +70,22 @@ final class Validate
                 foreach ($schema as $item => $rules) {
                     if (!is_array($rules) && is_object($rules)) {
                         if (!$rules->generate()) {
-                            throw new ValidationException("This rule is not a valid! method generate does not exist");
+                            throw new ValidationException('This rule is not a valid! method generate does not exist');
                         }
                         $rules = $rules->generate();
                     }
                     $class_namespace = array_keys($rules)[0];
-                    if ($class_namespace == "any") continue;
-                    $validator_class = str_replace("Rules", "Validator", $class_namespace);
-                    $reflexion = new \ReflectionClass($validator_class);
+                    if ($class_namespace == 'any') continue;
+                    $validator_class = str_replace('Rules', 'Validator', $class_namespace);
 
-                    $instance = $reflexion->newInstance($item, $resource);
+                    $instance = Application::make($validator_class, [
+                        $item,
+                        $resource
+                    ]);
 
                     foreach ($rules[$class_namespace] as $method => $params) {
                         if (method_exists($instance, $method)) {
-                            call_user_func_array([$instance, $method], [$params]);
+                            Application::container()->call([$instance, $method], [$params]);
                         }
                     }
                     $result = $instance->result();
@@ -101,18 +105,24 @@ final class Validate
     }
 
     /**
-     * @param array $item
+     * Add an error to the error list
+     *
+     * @param MessageBuilderContracts $item
      * @return void
      */
-    private function addError(MessageBuilderContracts $item)
+    private function addError(MessageBuilderContracts $item): void
     {
         $this->errors[] = $item->generate();
     }
 
     /**
+     * Get validation errors
+     * 1. if the validation passed, the array will be empty
+     * 2. if the validation failed, the array will contain the errors
+     * 
      * @return array
      */
-    public function errors(): array
+    public function getErrors(): array
     {
         return $this->errors;
     }

--- a/src/Core/Validation/Validator/ArrayValidator.php
+++ b/src/Core/Validation/Validator/ArrayValidator.php
@@ -29,11 +29,10 @@ final class ArrayValidator extends ValidatorProvider
 
     /**
      * @param int $rule
-     * @return void
+     *
      */
     public function max(int $rule): void
     {
-        // TODO: Implement max() method.
         if ($this->checkNotPositiveParamMethod($rule, true)) return;
         if (count($this->field_value) > $rule) {
             $this->messageItem

--- a/src/Core/Validation/Validator/ArrayValidator.php
+++ b/src/Core/Validation/Validator/ArrayValidator.php
@@ -55,7 +55,7 @@ final class ArrayValidator extends ValidatorProvider
         $element_source = $this->data_source[$this->field_name];
         $validate->check($element_source, $elements);
         if (!$validate->passed()) {
-            foreach ($validate->errors() as $error) $this->addError($error);
+            foreach ($validate->getErrors() as $error) $this->addError($error);
         }
     }
 

--- a/src/Core/Validation/Validator/BooleanValidator.php
+++ b/src/Core/Validation/Validator/BooleanValidator.php
@@ -40,12 +40,12 @@ final class BooleanValidator extends ValidatorProvider
 
     /**
      *
-     * @param string|null $itemKey
+     * @param string $itemKey
      * @return boolean
      */
-    private function isBoolean(string $itemKey = null): bool
+    private function isBoolean(string $itemKey = ""): bool
     {
-        $item_to_check = !$itemKey ? $this->field_name : $itemKey;
+        $item_to_check = (strlen(trim($itemKey))) > 0 ? $itemKey : $this->field_name;
         $val = $this->data_source[$item_to_check];
 
         $regex = "/^(true|false)$/";
@@ -64,7 +64,7 @@ final class BooleanValidator extends ValidatorProvider
      * @param $rule
      * @return void
      */
-    public function min($rule)
+    public function min($rule): void
     {
     }
 
@@ -72,7 +72,7 @@ final class BooleanValidator extends ValidatorProvider
      * @param $rule
      * @return void
      */
-    public function max($rule)
+    public function max($rule): void
     {
     }
 

--- a/src/Core/Validation/Validator/DateValidator.php
+++ b/src/Core/Validation/Validator/DateValidator.php
@@ -57,7 +57,7 @@ final class DateValidator extends ValidatorProvider
     /**
      * @return void
      */
-    public function now()
+    public function now(): void
     {
         $min_date_time = strtotime('now');
         $min_date = date('d/F/Y', $min_date_time);
@@ -73,11 +73,13 @@ final class DateValidator extends ValidatorProvider
     }
 
     /**
+     * While trying to get day validation, use this module
+     *
      * @param string|null $times
+     *
      * @return  void
-     * while trying to get day validation use this module
      */
-    public function today(string $times = null)
+    public function today(string $times = null): void
     {
         $min_date_time = strtotime("now {$times}");
         $min_date = date('d/F/Y', $min_date_time);
@@ -93,11 +95,13 @@ final class DateValidator extends ValidatorProvider
     }
 
     /**
+     * Get the min date control from the given date
+     *
      * @param string|null $rule
+     *
      * @return void
-     * get the min date control from the given date
      */
-    public function min($rule)
+    public function min($rule): void
     {
         /**
          * $regex= "#[a-zA-Z]#";
@@ -120,11 +124,13 @@ final class DateValidator extends ValidatorProvider
     }
 
     /**
+     * While try to check maximum date of a defined period use this module
+     *
      * @param string|null $rule
+     *
      * @return void
-     * while try to check maximum date of a defined period use this module
      */
-    public function max($rule)
+    public function max($rule): void
     {
         $rule = $rule ?? 'now';
         $max_date_time = strtotime($rule);

--- a/src/Core/Validation/Validator/NumberValidator.php
+++ b/src/Core/Validation/Validator/NumberValidator.php
@@ -56,7 +56,7 @@ final class NumberValidator extends ValidatorProvider
      * @param int $rule
      * @return void
      */
-    public function min(int $rule)
+    public function min(int $rule): void
     {
         if ((int)$this->field_value < $rule) {
             $this->messageItem
@@ -72,7 +72,7 @@ final class NumberValidator extends ValidatorProvider
      * @param int $rule
      * @return void
      */
-    public function max(int $rule)
+    public function max(int $rule): void
     {
         if ((int)$this->field_value > $rule) {
             $this->messageItem
@@ -85,9 +85,9 @@ final class NumberValidator extends ValidatorProvider
     }
 
     /**
-     *
+     * @return void
      */
-    public function positive()
+    public function positive(): void
     {
         if ((int)$this->field_value < 0) {
             $this->messageItem

--- a/src/Core/Validation/Validator/StringValidator.php
+++ b/src/Core/Validation/Validator/StringValidator.php
@@ -6,6 +6,11 @@
 
 namespace Wepesi\Core\Validation\Validator;
 
+use Wepesi\Core\Application;
+use Wepesi\Core\Database\Database;
+use Wepesi\Core\Database\WhereQueryBuilder\WhereBuilder;
+use Wepesi\Core\Database\WhereQueryBuilder\WhereConditions;
+use Wepesi\Core\Escape;
 use Wepesi\Core\Validation\Providers\ValidatorProvider;
 
 /**
@@ -68,7 +73,7 @@ final class StringValidator extends ValidatorProvider
     /**
      *
      */
-    public function email()
+    public function email(): void
     {
         if (!filter_var($this->field_value, FILTER_VALIDATE_EMAIL)) {
             $this->messageItem
@@ -86,7 +91,7 @@ final class StringValidator extends ValidatorProvider
      * www.[domain].[extension]
      *
      */
-    public function url()
+    public function url(): void
     {
         if (!preg_match("/\b(?:(?:https?|ftp):\/\/|www\.)[-a-z0-9+&@#\/%?=~_|!:,.;]*[-a-z0-9+&@#\/%=~_|]/i", $this->field_value)) {
             $this->messageItem
@@ -102,7 +107,7 @@ final class StringValidator extends ValidatorProvider
      * @param string $key_to_match
      *
      */
-    public function match(string $key_to_match)
+    public function match(string $key_to_match): void
     {
         $this->isStringAndValid($key_to_match);
         if (isset($this->data_source[$key_to_match]) && (strlen($this->field_value) != strlen($this->data_source[$key_to_match])) && ($this->field_value != $this->data_source[$key_to_match])) {
@@ -139,10 +144,9 @@ final class StringValidator extends ValidatorProvider
     }
 
     /**
-     * @param string $ip_address
      * @return void
      */
-    public function addressIp()
+    public function addressIp(): void
     {
         if (!filter_var($this->field_value, FILTER_VALIDATE_IP)) {
             $this->messageItem
@@ -157,7 +161,7 @@ final class StringValidator extends ValidatorProvider
      * @param string $ip_address
      * @return void
      */
-    public function addressIpv6(string $ip_address)
+    public function addressIpv6(string $ip_address): void
     {
         if (!filter_var($ip_address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
             $this->messageItem
@@ -173,11 +177,11 @@ final class StringValidator extends ValidatorProvider
      * @return $this
      * @throws \Exception
      */
-    public function unique(string $table_name)
+    public function unique(string $table_name): StringValidator
     {
-        $db = \Wepesi\Core\Database\Database::getInstance();
-        $condition = (new \Wepesi\Core\Database\WhereQueryBuilder\WhereConditions($this->field_name))->isEqualTo(\Wepesi\Core\Escape::encode($this->field_value));
-        $where = (new \Wepesi\Core\Database\WhereQueryBuilder\WhereBuilder())->andOption($condition);
+        $db = Application::make(Database::class);
+        $condition = Application::make(WhereConditions::class,[$this->field_name])->isEqualTo(Escape::encode($this->field_value));
+        $where = Application::make(WhereBuilder::class)->andOption($condition);
         $check_uniq = $db->get($table_name)->where($where)->result();
         if ($db->error()) {
             $this->messageItem

--- a/src/Core/View/Providers/Contracts/ViewEngineContracts.php
+++ b/src/Core/View/Providers/Contracts/ViewEngineContracts.php
@@ -47,7 +47,7 @@ interface ViewEngineContracts
     public function setLayoutContent(string $layout_name): void;
 
     /**
-     * reset view to default configuration
+     * reset the view to the default configuration
      */
     public function flush(): void;
 }


### PR DESCRIPTION
This pull request introduces a Dependency Injection (DI) container to the framework, refactors the `Application` class to use the container for service resolution, and sets up a new service provider system. The changes make the application more modular, testable, and configurable by centralizing service management and dependency resolution.

**Dependency Injection Container Integration:**

* Added a new `Container` class implementing the `ContainerContracts` interface, providing methods for binding, singleton registration, instance registration, service resolution, and dependency injection, along with circular dependency detection. 
* Refactored the `Application` class to accept a `ContainerContracts` instance in its constructor, store it statically, and use it for all service resolution. Added static methods for accessing and manipulating the container (`container`, `make`, `bind`, `singleton`). 

**Service Registration and Resolution:**

* Implemented `registerCoreServices` and `loadServiceProviders` in `Application` to register all core framework services (e.g., `Router`, `Database`, `Request`, `View`, etc.) in the container, and to load user-defined service bindings from a new `config/services.php` file. 
* Changed service instantiation throughout `Application` to use the container, including database, router, and other core components. 

**Application Bootstrap Changes:**

* Updated `index.php` to instantiate and pass the DI container to the `Application`, ensuring all dependencies are resolved through the container.

**Minor Fixes:**

* Fixed a method call in `exampleValidation.php` to use `getErrors()` instead of `errors()`. 

These changes set the foundation for a more flexible and maintainable architecture by decoupling service creation and management from the application logic.

closes #231 